### PR TITLE
Replace fetch() call with CapacitorHttp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,10 @@ android-template/app/app.iml
 .project
 .env
 capacitor-build.log
+capacitor.build.gradle
+capacitor.settings.gradle
+tsconfig.app.tsbuildinfo
+tsconfig.node.tsbuildinfo
 
 # Carthage and Carthage-built binaries
 Carthage

--- a/app/capacitor.config.ts
+++ b/app/capacitor.config.ts
@@ -3,7 +3,12 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'com.example.app',
   appName: 'DDS-OfflineMap-POC',
-  webDir: 'dist'
+  webDir: 'dist',
+  plugins: {
+    CapacitorHttp: {
+      enabled: true,
+    }
+  }
 };
 
 export default config;

--- a/app/ios/App/Podfile
+++ b/app/ios/App/Podfile
@@ -11,6 +11,7 @@ install! 'cocoapods', :disable_input_output_paths => true
 def capacitor_pods
   pod 'Capacitor', :path => '../../node_modules/@capacitor/ios'
   pod 'CapacitorCordova', :path => '../../node_modules/@capacitor/ios'
+
 end
 
 target 'App' do

--- a/app/src/Components/views/DatasetList/DatasetList.tsx
+++ b/app/src/Components/views/DatasetList/DatasetList.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect } from 'react';
+import { CapacitorHttp } from '@capacitor/core';
 import { CommonFullCont } from '../../../assets/common-styles/common.styles';
 import { xml2js } from 'xml-js';
 import AppContext from '../../../providers/context';
@@ -15,9 +16,9 @@ const DatasetList = () => {
 
   useEffect(() => {
     async function fetchCapabilities() {
-      const response = await fetch(url);
+      const response = await CapacitorHttp.get({url: url});
       try {
-        const body = await response.text();
+        const body = await response.data;
         const capabilities = xml2js(body, { compact: true })[
           'wfs:WFS_Capabilities'
         ]['FeatureTypeList']['FeatureType'];


### PR DESCRIPTION
By default, Capacitor doesn't replace `fetch()` with native-equivalent calls, so it doesn't work on iOS.and Android. This has been replaced with `CapcitorHttp`, which does.

Some `.gitignore` changes have also been slipstreamed in.