### PR TITLE
Header CSS fixes for small screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # WetpaddlersV2
+
 DDS Hackathon 2024 product:  Offline Map POC
+
+## iOS builds
+
+### Setup
+
+```sh
+brew install cocoapods
+cd Wetpaddlersv2/app/ios/App
+pod install
+```
+
+### Build
+
+```sh
+cd Wetpaddlersv2/app
+npm run build:dev
+npx cap sync
+npx cap open ios
+```
+(remove `:dev` when building for production)
+
+Then, choose a device and hit the "play" button.
+
+If you run into an error with `xcode-select` during `npx cap sync`, open Xcode > Settings > Locations and select the Command Line Tools (even if there's only one available in the dropdown).

--- a/app/package.json
+++ b/app/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "build:dev": "vite build",
     "lint": "eslint .",
     "preview": "vite --host"
   },

--- a/app/src/Components/Header/Header.style.ts
+++ b/app/src/Components/Header/Header.style.ts
@@ -16,7 +16,7 @@ export const StyledHeader = styled.header`
   padding-left: 1em;
   border-bottom: 1pt solid black;
   h1 {
-    font-size: 20pt;
+    font-size: min(2em, 3.5vw);
     margin: 0;
   }
   button:last-child {
@@ -36,7 +36,7 @@ export const StyledUl = styled.ul`
   display: flex;
 `;
 export const StyledLi = styled.li`
-  margin-left: 1rem;
+  margin-left: min(18pt, 4vw);
   font-size: 18pt;
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
Font size in the header now scales according to screen width. At this point in time, however, it doesn't take into account physical holes in the screen (e.g. iPhone camera holes, notches).

A new build script has also been added to (temporarily) bypass linting rules: `npm run build:dev`.