### PR TITLE
fix pmtiles URL by adding placeholders for z,x,y coordinates

### DIFF
--- a/app/src/Components/views/Map/Map.tsx
+++ b/app/src/Components/views/Map/Map.tsx
@@ -143,7 +143,7 @@ const Map = (props: any) => {
               maxzoom: 24,
             },
           ]}
-          url='pmtiles://https://nrs.objectstore.gov.bc.ca/uphjps/invasives-local.pmtiles'
+          url='pmtiles://https://nrs.objectstore.gov.bc.ca/uphjps/invasives-local.pmtiles/{z}/{x}/{y}'
           
         />
       </MapContent>


### PR DESCRIPTION
The error was fixed by adding ZXY placeholders at the end of the pomtiles URL.
These values will be set by maplibre for each tiles request and then are extracted and translated into byte ranges by the pmtiles protocol handler that is executed instead of the actual HTTP request.

Unfortunatley I could not find any documentation on this in the pmtile package but the code clearly show what needs to be done.
https://github.com/protomaps/PMTiles/blob/main/js/adapters.ts#L215

We will discuss the creation of a full pmtiles example with the MapComponents devs.